### PR TITLE
Configurable figsize

### DIFF
--- a/src/marketmetrics/__init__.py
+++ b/src/marketmetrics/__init__.py
@@ -353,14 +353,24 @@ def main() -> int:
 
     if args.symbols and args.period and args.short and args.long:
         config = Config(
-            symbols=args.symbols, period=args.period, short=args.short, long=args.long, figsize=args.figsize
+            symbols=args.symbols,
+            period=args.period,
+            short=args.short,
+            long=args.long,
+            figsize=args.figsize,
         )
     else:
         config = config_from_dialog()
 
     for symbol in config.symbols:
         plot_stock_data(
-            symbol, config.period, config.start, config.end, config.short, config.long, figsize=config.figsize
+            symbol,
+            config.period,
+            config.start,
+            config.end,
+            config.short,
+            config.long,
+            figsize=config.figsize,
         )
 
     plt.show()

--- a/src/marketmetrics/__init__.py
+++ b/src/marketmetrics/__init__.py
@@ -17,6 +17,7 @@ def plot_stock_data(
     end: str,
     short_window: int,
     long_window: int,
+    figsize: tuple,
 ):
     company = yf.Ticker(symbol)
     company_history = company.history(interval="1d", start=start, end=end)
@@ -49,7 +50,7 @@ def plot_stock_data(
         for level in [0.236, 0.382, 0.5, 0.618, 0.786]
     ]
 
-    fig = plt.figure(figsize=(12, 24))
+    fig = plt.figure(figsize=figsize)
     main_ax = fig.add_subplot(6, 1, (1, 3))
     rsi_ax = fig.add_subplot(6, 1, 4)
     volume_ax = fig.add_subplot(6, 1, 5)
@@ -337,6 +338,13 @@ def main() -> int:
         type=int,
         help="Long window for moving average. E.g., 100, 200",
     )
+    parser.add_argument(
+        "--figsize",
+        type=int,
+        nargs=2,
+        help="Figure size in inches. E.g., 16 16",
+        default=(16, 16),
+    )
     parser.add_argument("--debug", type=bool, help="Enable debug mode", default=False)
     args = parser.parse_args()
 
@@ -345,14 +353,14 @@ def main() -> int:
 
     if args.symbols and args.period and args.short and args.long:
         config = Config(
-            symbols=args.symbols, period=args.period, short=args.short, long=args.long
+            symbols=args.symbols, period=args.period, short=args.short, long=args.long, figsize=args.figsize
         )
     else:
         config = config_from_dialog()
 
     for symbol in config.symbols:
         plot_stock_data(
-            symbol, config.period, config.start, config.end, config.short, config.long
+            symbol, config.period, config.start, config.end, config.short, config.long, figsize=config.figsize
         )
 
     plt.show()

--- a/src/marketmetrics/config.py
+++ b/src/marketmetrics/config.py
@@ -68,5 +68,9 @@ def config_from_dialog() -> Config:
         "Input", "Enter long moving average window:", initialvalue=200
     )
     return Config(
-        symbols=symbols.split(), period=period, short=short_window, long=long_window, figsize=(16, 16)
+        symbols=symbols.split(),
+        period=period,
+        short=short_window,
+        long=long_window,
+        figsize=(16, 16),
     )

--- a/src/marketmetrics/config.py
+++ b/src/marketmetrics/config.py
@@ -14,6 +14,7 @@ class Config:
     long: int
     start: Optional[str] = field(init=False, default=None)
     end: Optional[str] = field(init=False, default=None)
+    figsize: tuple
 
     def __post_init__(self):
         self.end = datetime.now().strftime("%Y-%m-%d")
@@ -67,5 +68,5 @@ def config_from_dialog() -> Config:
         "Input", "Enter long moving average window:", initialvalue=200
     )
     return Config(
-        symbols=symbols.split(), period=period, short=short_window, long=long_window
+        symbols=symbols.split(), period=period, short=short_window, long=long_window, figsize=(16, 16)
     )


### PR DESCRIPTION
New argument, `figsize`. It is not allowed to set via dialog.

```
marketmetrics --help
usage: marketmetrics [-h] [--symbols SYMBOLS [SYMBOLS ...]] [--period PERIOD] [--short SHORT] [--long LONG] [--figsize FIGSIZE FIGSIZE] [--debug DEBUG]

Market Metrics: A Python application for technical stock market analysis.

options:
  -h, --help            show this help message and exit
  --symbols SYMBOLS [SYMBOLS ...]
                        E.g., DDOG MSFT VOO
  --period PERIOD       1d,5d,1mo,3mo,6mo,1y,2y,5y,10y,ytd,max
  --short SHORT         Short window for moving average. E.g., 20, 50
  --long LONG           Long window for moving average. E.g., 100, 200
  --figsize FIGSIZE FIGSIZE
                        Figure size in inches. E.g., 16 16
  --debug DEBUG         Enable debug mode
```